### PR TITLE
support for all types of curvature and boundary conditions

### DIFF
--- a/src/exadata.py
+++ b/src/exadata.py
@@ -37,7 +37,9 @@ class elem:
 		#                    x,y,z   lz      ly      lx
 		self.pos  = np.zeros((3     , lr1[2], lr1[1], lr1[0]))
 		#                    one per edge
-		self.curv = np.zeros((12, 1))
+		self.curv = np.zeros((12, 5))
+		# curvature type
+		self.ccurv = ['' for i in range(12)]
 		#                    u,v,w   lz      ly      lx
 		self.vel  = np.zeros((3     , lr1[2], lr1[1], lr1[0]))
       #                    p       lz      ly      lx     
@@ -47,7 +49,7 @@ class elem:
       #                    s_i     lz      ly      lx     
 		self.scal = np.zeros((var[4], lr1[2], lr1[1], lr1[0]))
 		#                    list of 8 parameters, one per face
-		self.bcs  = np.zeros((6), dtype='a1, i4, i4, f8, f8, f8, f8, f8')
+		self.bcs  = np.zeros((6), dtype='U3, i4, i4, f8, f8, f8, f8, f8')
 
 #==============================================================================
 class exadata:

--- a/src/neksuite.py
+++ b/src/neksuite.py
@@ -504,19 +504,10 @@ def readrea(fname):
 				data.elem[iel].bcs[iface][5] = float(line[38:52])
 				data.elem[iel].bcs[iface][6] = float(line[52:66])
 				data.elem[iel].bcs[iface][7] = float(line[66:80])
-			elif (nel < 1e5):
-				data.elem[iel].bcs[iface][0] = line[1:3].strip()
-				data.elem[iel].bcs[iface][1] = int(line[4:10])
-				data.elem[iel].bcs[iface][2] = iface + 1
-				data.elem[iel].bcs[iface][3] = float(line[10:24])
-				data.elem[iel].bcs[iface][4] = float(line[24:38])
-				data.elem[iel].bcs[iface][5] = float(line[38:52])
-				data.elem[iel].bcs[iface][6] = float(line[52:66])
-				data.elem[iel].bcs[iface][7] = float(line[66:80])
 			elif (nel < 1e6):
 				data.elem[iel].bcs[iface][0] = line[1:3].strip()
-				data.elem[iel].bcs[iface][1] = int(line[4:10])
-				data.elem[iel].bcs[iface][2] = iface + 1
+				data.elem[iel].bcs[iface][1] = int(line[4:9])
+				data.elem[iel].bcs[iface][2] = int(line[9:10])
 				data.elem[iel].bcs[iface][3] = float(line[10:24])
 				data.elem[iel].bcs[iface][4] = float(line[24:38])
 				data.elem[iel].bcs[iface][5] = float(line[38:52])
@@ -756,12 +747,9 @@ def writerea(fname, data):
 			if (data.nel < 1e3):
 				outfile.write(' {0:2s} {1:3d}{2:3d}{3:14.6e}{4:14.6e}{5:14.6e}{6:14.6e}{7:14.6e}\n'.format(
 					data.elem[iel].bcs[iface][0], data.elem[iel].bcs[iface][1], data.elem[iel].bcs[iface][2], data.elem[iel].bcs[iface][3], data.elem[iel].bcs[iface][4], data.elem[iel].bcs[iface][5], data.elem[iel].bcs[iface][6], data.elem[iel].bcs[iface][7]))
-			elif (data.nel < 1e5):
-				outfile.write(' {0:2s} {1:6d}{2:14.6e}{3:14.6e}{4:14.6e}{5:14.6e}{6:14.6e}\n'.format(
-					data.elem[iel].bcs[iface][0], data.elem[iel].bcs[iface][1], data.elem[iel].bcs[iface][3], data.elem[iel].bcs[iface][4], data.elem[iel].bcs[iface][5], data.elem[iel].bcs[iface][6], data.elem[iel].bcs[iface][7]))
 			elif (data.nel < 1e6):
-				outfile.write(' {0:2s} {1:6d}{2:14.6e}{3:14.6e}{4:14.6e}{5:14.6e}{6:14.6e}\n'.format(
-					data.elem[iel].bcs[iface][0], data.elem[iel].bcs[iface][1], data.elem[iel].bcs[iface][3], data.elem[iel].bcs[iface][4], data.elem[iel].bcs[iface][5], data.elem[iel].bcs[iface][6], data.elem[iel].bcs[iface][7]))
+				outfile.write(' {0:2s} {1:5d}{2:1d}{3:14.6e}{4:14.6e}{5:14.6e}{6:14.6e}{7:14.6e}\n'.format(
+					data.elem[iel].bcs[iface][0], data.elem[iel].bcs[iface][1], data.elem[iel].bcs[iface][2], data.elem[iel].bcs[iface][3], data.elem[iel].bcs[iface][4], data.elem[iel].bcs[iface][5], data.elem[iel].bcs[iface][6], data.elem[iel].bcs[iface][7]))
 			else:
 				outfile.write(' {0:2s} {1:11d}{2:1d}{3:18.11e}{4:18.11e}{5:18.11e}{6:18.11e}{7:18.11e}\n'.format(
 					data.elem[iel].bcs[iface][0], data.elem[iel].bcs[iface][1], data.elem[iel].bcs[iface][2], data.elem[iel].bcs[iface][3], data.elem[iel].bcs[iface][4], data.elem[iel].bcs[iface][5], data.elem[iel].bcs[iface][6], data.elem[iel].bcs[iface][7]))

--- a/src/neksuite.py
+++ b/src/neksuite.py
@@ -461,15 +461,30 @@ def readrea(fname):
 		if (nel < 1e3):
 			iedge = int(line[0:3])-1
 			iel   = int(line[3:6])-1
-			data.elem[iel].curv[iedge] = float(line[6:16])
+			data.elem[iel].curv[iedge][0] = float(line[6:20])
+			data.elem[iel].curv[iedge][1] = float(line[20:34])
+			data.elem[iel].curv[iedge][2] = float(line[34:48])
+			data.elem[iel].curv[iedge][3] = float(line[48:62])
+			data.elem[iel].curv[iedge][4] = float(line[62:76])
+			data.elem[iel].ccurv[iedge]   = line[76:79].split()[0]
 		elif (nel < 1e6):
 			iedge = int(line[0:2])-1
 			iel   = int(line[2:8])-1
-			data.elem[iel].curv[iedge] = float(line[8:18])
+			data.elem[iel].curv[iedge][0] = float(line[8:22])
+			data.elem[iel].curv[iedge][1] = float(line[22:36])
+			data.elem[iel].curv[iedge][2] = float(line[36:50])
+			data.elem[iel].curv[iedge][3] = float(line[50:64])
+			data.elem[iel].curv[iedge][4] = float(line[64:78])
+			data.elem[iel].ccurv[iedge]   = line[78:81].split()[0]
 		else:
 			iedge = int(line[0:2])-1
 			iel   = int(line[2:12])-1
-			data.elem[iel].curv[iedge] = float(line[12:22])
+			data.elem[iel].curv[iedge][0] = float(line[12:26])
+			data.elem[iel].curv[iedge][1] = float(line[26:40])
+			data.elem[iel].curv[iedge][2] = float(line[40:54])
+			data.elem[iel].curv[iedge][3] = float(line[54:68])
+			data.elem[iel].curv[iedge][4] = float(line[68:82])
+			data.elem[iel].ccurv[iedge]   = line[82:85].split()[0]
 	#
 	#---------------------------------------------------------------------------
 	# BOUNDARY CONDITIONS
@@ -717,21 +732,21 @@ def writerea(fname, data):
 		if (data.nel < 1e3):
 			#
 			for iedge in range(12):
-				if (data.elem[iel].curv[iedge] != 0.0):
-					outfile.write('{0:3d}{1:3d}{2:10.5f}{3:14.5f}{4:14.5f}{5:14.5f}{6:14.5f}     C\n'.format(
-						iedge+1, iel+1, data.elem[iel].curv[iedge][0], 0.0, 0.0, 0.0, 0.0))
+				if (data.elem[iel].ccurv[iedge] != ''):
+					outfile.write('{0:3d}{1:3d}{2:14.6e}{3:14.6e}{4:14.6e}{5:14.6e}{6:14.6e}{7:>2s}\n'.format(
+						iedge+1, iel+1, data.elem[iel].curv[iedge][0], data.elem[iel].curv[iedge][1], data.elem[iel].curv[iedge][2], data.elem[iel].curv[iedge][3], data.elem[iel].curv[iedge][4], data.elem[iel].ccurv[iedge]))
 		elif (data.nel < 1e6):
 			#
 			for iedge in range(12):
-				if (data.elem[iel].curv[iedge] != 0.0):
-					outfile.write('{0:2d}{1:6d}{2:10.5f}{3:14.5f}{4:14.5f}{5:14.5f}{6:14.5f}     C\n'.format(
-						iedge+1, iel+1, data.elem[iel].curv[iedge][0], 0., 0., 0., 0.))
+				if (data.elem[iel].ccurv[iedge] != ''):
+					outfile.write('{0:2d}{1:6d}{2:14.6e}{3:14.6e}{4:14.6e}{5:14.6e}{6:14.6e}{7:>2s}\n'.format(
+						iedge+1, iel+1, data.elem[iel].curv[iedge][0], data.elem[iel].curv[iedge][1], data.elem[iel].curv[iedge][2], data.elem[iel].curv[iedge][3], data.elem[iel].curv[iedge][4], data.elem[iel].ccurv[iedge]))
 		else:
 			#
 			for iedge in range(12):
-				if (data.elem[iel].curv[iedge] != 0.0):
-					outfile.write('{0:2d}{1:10d}{2:10.5f}{3:14.5f}{4:14.5f}{5:14.5f}{6:14.5f}     C\n'.format(
-						iedge+1, iel+1, data.elem[iel].curv[iedge][0], 0.0, 0.0, 0.0, 0.0))
+				if (data.elem[iel].ccurv[iedge] != ''):
+					outfile.write('{0:2d}{1:10d}{2:14.6e}{3:14.6e}{4:14.6e}{5:14.6e}{6:14.6e}{7:>2s}\n'.format(
+						iedge+1, iel+1, data.elem[iel].curv[iedge][0], data.elem[iel].curv[iedge][1], data.elem[iel].curv[iedge][2], data.elem[iel].curv[iedge][3], data.elem[iel].curv[iedge][4], data.elem[iel].ccurv[iedge]))
 	#
 	# boundary conditions data
 	outfile.write('  ***** BOUNDARY CONDITIONS *****\n')

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -59,7 +59,9 @@ def test_readrea():
 	assert field.lr1  == [2, 2, 1]
 	assert field.ndim == 2
 	assert field.nel  == 1248
-	assert (field.elem[0].pos[0][0][0][0] - 0.048383219999999998 ) < 1e-3
+	assert abs(field.elem[0].pos[0][0][0][0] - 0.048383219999999998 ) < 1e-3
+	assert abs(field.elem[887].curv[1, 0] - 1.21664) < 1e-3
+	assert field.elem[887].ccurv[1] == 'C'
 
 
 def test_writerea():

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -85,6 +85,8 @@ def test_writerea():
 	assert field.nel    == fieldw.nel
 	assert field.wdsz   == fieldw.wdsz
 	assert (field.elem[0].pos[0][0][0][0] - fieldw.elem[0].pos[0][0][0][0]) < 1e-3
+	assert abs(field.elem[887].curv[1, 0] - 1.21664) < 1e-3
+	assert field.elem[887].ccurv[1] == 'C'
 
 
 


### PR DESCRIPTION
Changes in readrea and writerea:
* read/write the curvature type and all five curvature parameters
* write curvature parameters in exponential format for better precision
* store boundary condition types as 3-character unicode strings

I haven't tested this with a very large mesh (nel>1e6).