### PR TITLE
Provide acess to submodules on import

### DIFF
--- a/pymech/__init__.py
+++ b/pymech/__init__.py
@@ -11,4 +11,10 @@
    log
 
 """
+
+from . import neksuite
+from . import simsonsuite
+
+__all__ = ["neksuite", "simsonsuite"]
+
 from ._version import __version__


### PR DESCRIPTION
Hi!

Would you consider a slight modification to the __init__? This way upon
`import pymech`
one can access the underlying functionality in `neksuite` and `simsonsuite`.
As it is right now, one needs to import the submodules directly.

Wasn't sure what the git flow here, so I worked directly on master.  Anyway, this is just a small suggestion.
Cheers!